### PR TITLE
Make one timer rather than a timer each iteration.

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,0 +1,2 @@
+tenets:
+  - import: codelingo/go/ticker-in-for-select

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -95,13 +95,17 @@ func cleanLists() {
  *  This is the main loop of the dispatcher.
  */
 func processMsgs() {
+	timerDuration := time.Second * 3
+	timer := time.NewTimer(timerDuration)
 	for {
 		select {
 		case res := <-fChannel:
+			timer.Stop()
 			addFile(res)
-		case <-time.After(time.Second * 3):
+		case <-timer.C:
 			cleanLists()
 		}
+		timer.Reset(timerDuration)
 	}
 }
 


### PR DESCRIPTION
Rather than creating a new timer for each iteration, one timer should be defined and reset after each iteration. When using time.After() it's valuable to know that ["The underlying Timer is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."](https://golang.org/src/time/sleep.go?s=4332:4733#L143)

This issue was found using the CodeLingo Tenet [ticker-in-for-select](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/go/ticker-in-for-select/codelingo.yaml) which I have added to the codelingo.yaml at the root of the repo.